### PR TITLE
Set up runtime exception mapper

### DIFF
--- a/src/main/java/io/stargate/sgv2/dynamoapi/StargateDynamoApi.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/StargateDynamoApi.java
@@ -1,8 +1,8 @@
 package io.stargate.sgv2.dynamoapi;
 
 import io.stargate.sgv2.api.common.config.constants.HttpConstants;
-import io.stargate.sgv2.api.common.exception.model.dto.ApiError;
 import io.stargate.sgv2.dynamoapi.constants.DynamoOpenApiConstants;
+import io.stargate.sgv2.dynamoapi.exception.DynamoError;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Components;
@@ -79,7 +79,7 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
                             @ExampleObject(
                                 ref = DynamoOpenApiConstants.Examples.GENERAL_BAD_REQUEST),
                           },
-                          schema = @Schema(implementation = ApiError.class))),
+                          schema = @Schema(implementation = DynamoError.class))),
               @APIResponse(
                   name = DynamoOpenApiConstants.Responses.GENERAL_401,
                   responseCode = "401",
@@ -91,7 +91,7 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
                             @ExampleObject(
                                 ref = DynamoOpenApiConstants.Examples.GENERAL_UNAUTHORIZED),
                           },
-                          schema = @Schema(implementation = ApiError.class))),
+                          schema = @Schema(implementation = DynamoError.class))),
               @APIResponse(
                   name = DynamoOpenApiConstants.Responses.GENERAL_404,
                   responseCode = "404",
@@ -99,7 +99,7 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
                   content =
                       @Content(
                           mediaType = MediaType.APPLICATION_JSON,
-                          schema = @Schema(implementation = ApiError.class))),
+                          schema = @Schema(implementation = DynamoError.class))),
               @APIResponse(
                   name = DynamoOpenApiConstants.Responses.GENERAL_500,
                   responseCode = "500",
@@ -111,6 +111,6 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
                             @ExampleObject(
                                 ref = DynamoOpenApiConstants.Examples.GENERAL_SERVER_SIDE_ERROR),
                           },
-                          schema = @Schema(implementation = ApiError.class))),
+                          schema = @Schema(implementation = DynamoError.class))),
             }))
 public class StargateDynamoApi extends Application {}

--- a/src/main/java/io/stargate/sgv2/dynamoapi/constants/AmazonConstants.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/constants/AmazonConstants.java
@@ -1,0 +1,7 @@
+package io.stargate.sgv2.dynamoapi.constants;
+
+public interface AmazonConstants {
+  // Exception related constants
+  String X_AMZN_ERROR_TYPE = "x-amzn-ErrorType";
+  String INTERNAL_SERVER_ERROR = "InternalServerError";
+}

--- a/src/main/java/io/stargate/sgv2/dynamoapi/exception/DynamoError.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/exception/DynamoError.java
@@ -1,0 +1,8 @@
+package io.stargate.sgv2.dynamoapi.exception;
+
+public record DynamoError(String __type, String message) {
+  public DynamoError(String __type, String message) {
+    this.__type = __type;
+    this.message = message;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/dynamoapi/exception/RuntimeExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/exception/RuntimeExceptionMapper.java
@@ -1,0 +1,27 @@
+package io.stargate.sgv2.dynamoapi.exception;
+
+import io.stargate.sgv2.dynamoapi.constants.AmazonConstants;
+import java.util.UUID;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RuntimeExceptionMapper {
+  private static final Logger logger = LoggerFactory.getLogger(RuntimeExceptionMapper.class);
+
+  @ServerExceptionMapper
+  public RestResponse<DynamoError> mapRuntimeException(RuntimeException e) {
+    String errorId = UUID.randomUUID().toString();
+    logger.error("Non-captured runtime exception, errorId[{}]", errorId, e);
+    DynamoError error =
+        new DynamoError(
+            RuntimeException.class.getName(),
+            String.format("ErrorId[%s], exception message: %s", errorId, e.getMessage()));
+
+    return RestResponse.ResponseBuilder.create(Response.Status.INTERNAL_SERVER_ERROR, error)
+        .header(AmazonConstants.X_AMZN_ERROR_TYPE, AmazonConstants.INTERNAL_SERVER_ERROR)
+        .build();
+  }
+}

--- a/src/main/java/io/stargate/sgv2/dynamoapi/resources/DynamoResourceApi.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/resources/DynamoResourceApi.java
@@ -1,6 +1,7 @@
 package io.stargate.sgv2.dynamoapi.resources;
 
 import io.stargate.sgv2.dynamoapi.constants.DynamoOpenApiConstants;
+import java.io.IOException;
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HeaderParam;
@@ -30,7 +31,8 @@ public interface DynamoResourceApi {
   Response handleRequest(
       @Context HttpHeaders headers,
       @Parameter(name = "X-Amz-Target") @HeaderParam("X-Amz-Target") String target,
-      @RequestBody(required = true) String payload);
+      @RequestBody(required = true) String payload)
+      throws IOException;
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)

--- a/src/main/java/io/stargate/sgv2/dynamoapi/resources/DynamoResourceImpl.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/resources/DynamoResourceImpl.java
@@ -4,7 +4,6 @@ import static io.stargate.sgv2.dynamoapi.dynamo.Proxy.awsRequestMapper;
 
 import com.amazonaws.AmazonWebServiceResult;
 import com.amazonaws.services.dynamodbv2.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.stargate.bridge.proto.QueryOuterClass;
 import io.stargate.sgv2.api.common.cql.builder.QueryBuilder;
 import io.stargate.sgv2.api.common.cql.builder.Replication;
@@ -33,58 +32,50 @@ public class DynamoResourceImpl implements DynamoResourceApi {
   @Inject QueryProxy queryProxy;
 
   @Override
-  public Response handleRequest(HttpHeaders headers, String target, String payload) {
+  public Response handleRequest(HttpHeaders headers, String target, String payload)
+      throws IOException {
     target = target.split("\\.")[1];
     DynamoStatementType statementType = DynamoStatementType.valueOf(target);
     byte[] response;
-    try {
-      AmazonWebServiceResult result;
-      switch (statementType) {
-        case CreateTable:
-          CreateTableRequest createTableRequest =
-              awsRequestMapper.readValue(payload, CreateTableRequest.class);
-          result = tableProxy.createTable(createTableRequest, bridge);
-          break;
-        case DeleteTable:
-          DeleteTableRequest deleteTableRequest =
-              awsRequestMapper.readValue(payload, DeleteTableRequest.class);
-          result = tableProxy.deleteTable(deleteTableRequest, bridge);
-          break;
-        case PutItem:
-          PutItemRequest putItemRequest = awsRequestMapper.readValue(payload, PutItemRequest.class);
-          result = itemProxy.putItem(putItemRequest, bridge);
-          break;
-        case GetItem:
-          GetItemRequest getItemRequest = awsRequestMapper.readValue(payload, GetItemRequest.class);
-          result = itemProxy.getItem(getItemRequest, bridge);
-          break;
-        case DeleteItem:
-          DeleteItemRequest deleteItemRequest =
-              awsRequestMapper.readValue(payload, DeleteItemRequest.class);
-          result = itemProxy.deleteItem(deleteItemRequest, bridge);
-          break;
-        case ListTables:
-          ListTablesRequest listTablesRequest =
-              awsRequestMapper.readValue(payload, ListTablesRequest.class);
-          result = tableProxy.listTables(listTablesRequest, bridge);
-          break;
-        case Query:
-          QueryRequest queryRequest = awsRequestMapper.readValue(payload, QueryRequest.class);
-          result = queryProxy.query(queryRequest, bridge);
-          break;
-        default:
-          throw new WebApplicationException(
-              "Invalid statement type: " + target, Response.Status.BAD_REQUEST);
-      }
-      response = awsRequestMapper.writeValueAsBytes(result);
-    } catch (JsonProcessingException ex) {
-      throw new WebApplicationException("Invalid payload", Response.Status.BAD_REQUEST);
-    } catch (IOException ex) {
-      throw new WebApplicationException(
-          "An error occurred when connecting to Cassandra", Response.Status.INTERNAL_SERVER_ERROR);
-    } catch (Exception ex) {
-      throw new WebApplicationException(ex, Response.Status.INTERNAL_SERVER_ERROR);
+    AmazonWebServiceResult result;
+    switch (statementType) {
+      case CreateTable:
+        CreateTableRequest createTableRequest =
+            awsRequestMapper.readValue(payload, CreateTableRequest.class);
+        result = tableProxy.createTable(createTableRequest, bridge);
+        break;
+      case DeleteTable:
+        DeleteTableRequest deleteTableRequest =
+            awsRequestMapper.readValue(payload, DeleteTableRequest.class);
+        result = tableProxy.deleteTable(deleteTableRequest, bridge);
+        break;
+      case PutItem:
+        PutItemRequest putItemRequest = awsRequestMapper.readValue(payload, PutItemRequest.class);
+        result = itemProxy.putItem(putItemRequest, bridge);
+        break;
+      case GetItem:
+        GetItemRequest getItemRequest = awsRequestMapper.readValue(payload, GetItemRequest.class);
+        result = itemProxy.getItem(getItemRequest, bridge);
+        break;
+      case DeleteItem:
+        DeleteItemRequest deleteItemRequest =
+            awsRequestMapper.readValue(payload, DeleteItemRequest.class);
+        result = itemProxy.deleteItem(deleteItemRequest, bridge);
+        break;
+      case ListTables:
+        ListTablesRequest listTablesRequest =
+            awsRequestMapper.readValue(payload, ListTablesRequest.class);
+        result = tableProxy.listTables(listTablesRequest, bridge);
+        break;
+      case Query:
+        QueryRequest queryRequest = awsRequestMapper.readValue(payload, QueryRequest.class);
+        result = queryProxy.query(queryRequest, bridge);
+        break;
+      default:
+        throw new WebApplicationException(
+            "Invalid statement type: " + target, Response.Status.BAD_REQUEST);
     }
+    response = awsRequestMapper.writeValueAsBytes(result);
     return Response.status(Response.Status.OK).entity(response).build();
   }
 

--- a/src/test/java/io/stargate/sgv2/dynamoapi/exception/RuntimeExceptionMapperTest.java
+++ b/src/test/java/io/stargate/sgv2/dynamoapi/exception/RuntimeExceptionMapperTest.java
@@ -1,0 +1,23 @@
+package io.stargate.sgv2.dynamoapi.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.Test;
+
+public class RuntimeExceptionMapperTest {
+
+  @Test
+  public void testExceptionMessage() {
+    String message = "Unknown exception";
+    RuntimeException ex = new RuntimeException(message);
+
+    RuntimeExceptionMapper mapper = new RuntimeExceptionMapper();
+
+    try (RestResponse<DynamoError> response = mapper.mapRuntimeException(ex)) {
+      assertEquals(500, response.getStatus());
+      assertTrue(response.getEntity().message().contains("exception message: Unknown exception"));
+    }
+  }
+}


### PR DESCRIPTION
This commit is an example of how to capture exceptions and returns appropriate http responses that AWS client could understand.

Related to https://github.com/li-boxuan/cassandra-dynamoDB-adapter/issues/4