### PR TITLE
Add more exception mappers and integration tests

### DIFF
--- a/src/main/java/io/stargate/sgv2/dynamoapi/constants/AmazonConstants.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/constants/AmazonConstants.java
@@ -3,5 +3,16 @@ package io.stargate.sgv2.dynamoapi.constants;
 public interface AmazonConstants {
   // Exception related constants
   String X_AMZN_ERROR_TYPE = "x-amzn-ErrorType";
+
+  // The error codes must be consistent with AmazonDynamoDBClient.java. Unfortunately,
+  // these string literals are spread across amazon client sdk codebase, and thus we
+  // have to manually collect them and list them here
+  // TODO: convert them into enum
   String INTERNAL_SERVER_ERROR = "InternalServerError";
+
+  String TABLE_NOT_FOUND_EXCEPTION = "TableNotFoundException";
+
+  String TABLE_ALREADY_EXISTS_EXCEPTION = "TableAlreadyExistsException";
+
+  String VALIDATION_EXCEPTION = "ValidationException";
 }

--- a/src/main/java/io/stargate/sgv2/dynamoapi/dynamo/QueryProxy.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/dynamo/QueryProxy.java
@@ -8,6 +8,7 @@ import io.stargate.bridge.proto.Schema;
 import io.stargate.sgv2.api.common.cql.builder.Predicate;
 import io.stargate.sgv2.api.common.cql.builder.QueryBuilder;
 import io.stargate.sgv2.api.common.grpc.StargateBridgeClient;
+import io.stargate.sgv2.dynamoapi.exception.DynamoDBException;
 import io.stargate.sgv2.dynamoapi.parser.ExpressionLexer;
 import io.stargate.sgv2.dynamoapi.parser.ExpressionParser;
 import io.stargate.sgv2.dynamoapi.parser.FilterExpressionVisitor;
@@ -112,8 +113,12 @@ public class QueryProxy extends ProjectiveProxy {
 
     java.util.function.Predicate<Map<String, AttributeValue>> pred =
         getFilterPredicate(queryRequest);
-
-    QueryOuterClass.Response response = bridge.executeQuery(query);
+    QueryOuterClass.Response response;
+    try {
+      response = bridge.executeQuery(query);
+    } catch (Exception ex) {
+      throw new DynamoDBException(ex);
+    }
     Collection<Map<String, AttributeValue>> resultRows =
         collectResults(
             response.getResultSet(),

--- a/src/main/java/io/stargate/sgv2/dynamoapi/exception/DynamoDBException.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/exception/DynamoDBException.java
@@ -1,0 +1,38 @@
+package io.stargate.sgv2.dynamoapi.exception;
+
+import io.stargate.sgv2.dynamoapi.constants.AmazonConstants;
+import javax.ws.rs.core.Response;
+
+/** Generic exception type for any unclassified exception */
+public class DynamoDBException extends RuntimeException {
+
+  final Response.Status status;
+  final String errorType;
+
+  public DynamoDBException(Throwable cause) {
+    super(cause);
+    this.status = Response.Status.INTERNAL_SERVER_ERROR;
+    this.errorType = AmazonConstants.INTERNAL_SERVER_ERROR;
+  }
+
+  public DynamoDBException(Response.Status status, String errorType, String message) {
+    super(message);
+    this.status = status;
+    this.errorType = errorType;
+  }
+
+  public DynamoDBException(
+      Response.Status status, String errorType, String message, Throwable cause) {
+    super(message, cause);
+    this.status = status;
+    this.errorType = errorType;
+  }
+
+  public Response.Status getStatus() {
+    return status;
+  }
+
+  public String getErrorType() {
+    return errorType;
+  }
+}

--- a/src/main/java/io/stargate/sgv2/dynamoapi/exception/DynamoDBExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/exception/DynamoDBExceptionMapper.java
@@ -1,0 +1,27 @@
+package io.stargate.sgv2.dynamoapi.exception;
+
+import io.stargate.sgv2.dynamoapi.constants.AmazonConstants;
+import java.util.UUID;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DynamoDBExceptionMapper {
+
+  private static final Logger logger = LoggerFactory.getLogger(DynamoDBExceptionMapper.class);
+
+  @ServerExceptionMapper
+  public RestResponse<DynamoError> mapException(DynamoDBException e) {
+    String errorId = UUID.randomUUID().toString();
+    logger.error("DynamoDB exception, errorId[{}]", errorId, e);
+    DynamoError error =
+        new DynamoError(
+            DynamoDBException.class.getName(),
+            String.format("ErrorId[%s], exception message: %s", errorId, e.getMessage()));
+
+    return RestResponse.ResponseBuilder.create(e.getStatus(), error)
+        .header(AmazonConstants.X_AMZN_ERROR_TYPE, e.getErrorType())
+        .build();
+  }
+}

--- a/src/main/java/io/stargate/sgv2/dynamoapi/exception/ValidationExceptionMapper.java
+++ b/src/main/java/io/stargate/sgv2/dynamoapi/exception/ValidationExceptionMapper.java
@@ -1,0 +1,29 @@
+package io.stargate.sgv2.dynamoapi.exception;
+
+import io.stargate.sgv2.dynamoapi.constants.AmazonConstants;
+import java.util.UUID;
+import javax.validation.ValidationException;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ValidationExceptionMapper {
+
+  private static final Logger logger = LoggerFactory.getLogger(ValidationExceptionMapper.class);
+
+  @ServerExceptionMapper
+  public RestResponse<DynamoError> mapException(ValidationException e) {
+    String errorId = UUID.randomUUID().toString();
+    logger.error("DynamoDB exception, errorId[{}]", errorId, e);
+    DynamoError error =
+        new DynamoError(
+            DynamoDBException.class.getName(),
+            String.format("ErrorId[%s], exception message: %s", errorId, e.getMessage()));
+
+    return RestResponse.ResponseBuilder.create(Response.Status.BAD_REQUEST, error)
+        .header(AmazonConstants.X_AMZN_ERROR_TYPE, AmazonConstants.VALIDATION_EXCEPTION)
+        .build();
+  }
+}

--- a/src/test/java/io/stargate/sgv2/dynamoapi/exception/DynamoDBExceptionMapperTest.java
+++ b/src/test/java/io/stargate/sgv2/dynamoapi/exception/DynamoDBExceptionMapperTest.java
@@ -1,0 +1,29 @@
+package io.stargate.sgv2.dynamoapi.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.stargate.sgv2.dynamoapi.constants.AmazonConstants;
+import javax.ws.rs.core.Response;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.Test;
+
+public class DynamoDBExceptionMapperTest {
+
+  @Test
+  public void testExceptionMessage() {
+    DynamoDBException ex =
+        new DynamoDBException(
+            Response.Status.BAD_REQUEST,
+            AmazonConstants.TABLE_ALREADY_EXISTS_EXCEPTION,
+            "table xxx already exists");
+
+    DynamoDBExceptionMapper mapper = new DynamoDBExceptionMapper();
+
+    try (RestResponse<DynamoError> response = mapper.mapException(ex)) {
+      assertEquals(400, response.getStatus());
+      assertTrue(
+          response.getEntity().message().contains("exception message: table xxx already exists"));
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/dynamoapi/exception/ValidationExceptionMapperTest.java
+++ b/src/test/java/io/stargate/sgv2/dynamoapi/exception/ValidationExceptionMapperTest.java
@@ -1,0 +1,27 @@
+package io.stargate.sgv2.dynamoapi.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.validation.ValidationException;
+import org.jboss.resteasy.reactive.RestResponse;
+import org.junit.jupiter.api.Test;
+
+public class ValidationExceptionMapperTest {
+
+  @Test
+  public void testExceptionMessage() {
+    ValidationException ex = new ValidationException("Limit in ListTables must be <= 100");
+
+    ValidationExceptionMapper mapper = new ValidationExceptionMapper();
+
+    try (RestResponse<DynamoError> response = mapper.mapException(ex)) {
+      assertEquals(400, response.getStatus());
+      assertTrue(
+          response
+              .getEntity()
+              .message()
+              .contains("exception message: Limit in ListTables must be <= 100"));
+    }
+  }
+}

--- a/src/test/java/io/stargate/sgv2/it/DynamoITBase.java
+++ b/src/test/java/io/stargate/sgv2/it/DynamoITBase.java
@@ -1,7 +1,10 @@
 package io.stargate.sgv2.it;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
@@ -62,6 +65,13 @@ public class DynamoITBase {
 
   protected RequestSpecification givenWithAuthToken(String authTokenValue) {
     return given().header(HttpConstants.AUTHENTICATION_TOKEN_HEADER_NAME, authTokenValue);
+  }
+
+  protected void assertException(AmazonServiceException expected, AmazonServiceException actual) {
+    assertEquals(expected.getErrorCode(), actual.getErrorCode());
+    assertEquals(expected.getErrorType(), actual.getErrorType());
+    // Our system also records a unique identifier of the exception, which amazon does not
+    assertTrue(expected.getMessage().contains(actual.getMessage()));
   }
 
   /*


### PR DESCRIPTION
This commit adds more exception mappers, including a
general exception mapper which aims to capture every
unclassified exception. This also adds a few test
cases to ensure the exception error message returned
to users is same or at least close to that from Amazon
DynamoDB.

Closes #4